### PR TITLE
added single asset screen into assets

### DIFF
--- a/app/App.js
+++ b/app/App.js
@@ -12,18 +12,18 @@ import SingleAsset from './components/pages/SingleAsset'
 
 const App = () => {
   return (
-    <SingleAsset />
-    // <AuthProvider>
-    //   <StyleProvider>
-    //     <NativeRouter>
-    //       <Switch>
-    //         <PublicRoute path='/login' component={LoginPage} />
-    //         <PrivateRoute path='/logout' component={LogoutPage} />
-    //         <PrivateRoute exact path={['/', '/home']} component={BasePage} />
-    //       </Switch>
-    //     </NativeRouter>
-    //   </StyleProvider>
-    // </AuthProvider>
+    // <SingleAsset />
+    <AuthProvider>
+      <StyleProvider>
+        <NativeRouter>
+          <Switch>
+            <PublicRoute path='/login' component={LoginPage} />
+            <PrivateRoute path='/logout' component={LogoutPage} />
+            <PrivateRoute exact path={['/', '/home']} component={BasePage} />
+          </Switch>
+        </NativeRouter>
+      </StyleProvider>
+    </AuthProvider>
   )
 }
 

--- a/app/components/AssetListItem.js
+++ b/app/components/AssetListItem.js
@@ -1,9 +1,9 @@
 import React from 'react'
 import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 
-export default function AssetListItem({ name, date, image }) {
+export default function AssetListItem({ name, date, image, onPress }) {
   return (
-    <TouchableOpacity style={styles.container} onPress={(params) => {}}>
+    <TouchableOpacity style={styles.container} onPress={onPress}>
       <View style={styles.imageContainer}>
         <Image source={image} style={styles.image} />
       </View>

--- a/app/components/pages/BrowseAssetsScreen.js
+++ b/app/components/pages/BrowseAssetsScreen.js
@@ -1,8 +1,9 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { FlatList } from 'react-native'
 import { StyleSheet, Text, View } from 'react-native'
 import AssetListItem from '../AssetListItem'
 import colors from '../../config/colors'
+import SingleAsset from './SingleAsset'
 
 const assets = [
   {
@@ -44,22 +45,34 @@ const assets = [
 ]
 
 export default function BrowseAssetsScreen() {
+  const [showBrowseScreen, setShowBrowseScreen] = useState(true)
   return (
     <View style={styles.container}>
-      <FlatList
-        data={assets}
-        renderItem={({ item }) => {
-          return (
-            <AssetListItem
-              name={item.name}
-              date={item.date}
-              image={item.image}
-            />
-          )
-        }}
-        keyExtractor={(item) => item.id}
-        numColumns={2}
-      ></FlatList>
+      {showBrowseScreen && (
+        <FlatList
+          data={assets}
+          renderItem={({ item }) => {
+            return (
+              <AssetListItem
+                name={item.name}
+                date={item.date}
+                image={item.image}
+                onPress={() => setShowBrowseScreen(false)}
+              />
+            )
+          }}
+          keyExtractor={(item) => item.id}
+          numColumns={2}
+        ></FlatList>
+      )}
+
+      {!showBrowseScreen && (
+        <SingleAsset
+          goBackToBrowseAssets={() => {
+            setShowBrowseScreen(true)
+          }}
+        />
+      )}
     </View>
   )
 }

--- a/app/components/pages/SingleAsset.js
+++ b/app/components/pages/SingleAsset.js
@@ -23,7 +23,7 @@ const initialData = []
 // this is temporary - get rid of me
 var idNum = 2
 
-export default function SingleAsset() {
+export default function SingleAsset({ goBackToBrowseAssets }) {
   const [logData, setLogData] = useState(initialData)
   const [modalVisible, setModalVisible] = useState(false)
 
@@ -48,6 +48,12 @@ export default function SingleAsset() {
           }}
           title='Add Entry'
           color='#841584'
+          accessibilityLabel='Learn more about this purple button'
+        />
+        <Button
+          onPress={goBackToBrowseAssets}
+          title='Go Back'
+          color={colors.blue}
           accessibilityLabel='Learn more about this purple button'
         />
       </View>


### PR DESCRIPTION
Include the single asset screen with `BrowseAssetScreen`. In the future this needs to be refactored to be more scalable

![sprint 1 log entry temp inclusion](https://user-images.githubusercontent.com/59373288/133000965-319dd2b2-b59f-4508-b7a2-3b6dbb35ca84.gif)
